### PR TITLE
Use R2 v1.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "R2": "~1.3.1"
+    "R2": "~1.4.0"
   }
 }


### PR DESCRIPTION
R2 moved to a new minor version and `~1.3.1` does not cover that, so change the rule.
